### PR TITLE
Allow pass-through options for IO::Socket::SSL

### DIFF
--- a/Simple.pm
+++ b/Simple.pm
@@ -42,6 +42,11 @@ sub new {
         $opts{use_ssl} = 1;
     }
 
+    if( $opts{ssl_opts} ) {
+        $self->{ssl_opts} = $opts{ssl_opts};
+        $opts{use_ssl} = 1;
+    }
+
     if( $opts{use_ssl} ) {
         eval {
             require IO::Socket::SSL;
@@ -163,6 +168,7 @@ sub _connect {
             Proto    => 'tcp',
             ( $self->{bindaddr} ? ( LocalAddr => $self->{bindaddr} ) : () ),
             ( $_[0]->{ssl_version} ? (SSL_version => $self->{ssl_version}) : ()),
+            ( $self->{ssl_opts} ? (%{$self->{ssl_opts}}) : ()),
         );
     }
 

--- a/Simple.pod
+++ b/Simple.pod
@@ -105,6 +105,24 @@ v3/v2 auto negotiation -- it may have changed by the time you read this.
 
 Warning: setting this will also set use_ssl.
 
+=item ssl_opts => { ... }
+
+Pass-through options for L<IO::Socket::SSL>.  See L<IO::Socket::SSL> for a list of valid options.
+
+Example:
+
+  my $imap_dest = Net::IMAP::Simple->new(
+    $server,
+    port => $port,
+    use_ssl => 1,
+    ssl_opts => {
+      SSL_ca_path => '/usr/share/ca-certificates/',
+      SSL_verify_mode => 'SSL_VERIFY_PEER',
+    }
+  );
+
+Warning: setting this will also set use_ssl.
+
 =item bindaddr => str
 
 Assign a local address to bind


### PR DESCRIPTION
As of IO::Socket::SSL v1.79 it now warns if SSL_verify_mode is set to SSL_VERIFY_NONE.
  These changes give the user control over any of the options they wish to set in IO::Socket::SSL.
