### PR TITLE
Make the end parentheses match more explicit, debug when enabled with a ...

### DIFF
--- a/Simple.pm
+++ b/Simple.pm
@@ -1171,16 +1171,19 @@ sub _read_multiline {
         }
     }
 
-    if($list and $lines[-1] !~ /\)/) {
-        $self->_debug( caller, __LINE__, '_read_multiline', "Looking for ending parenthsis match..." );
+    if($list and $lines[-1] !~ /^\)[\r\n]*$/) {
+        $self->_debug( caller, __LINE__, '_read_multiline', "Looking for ending parenthses match..." ) if $self->{debug};
 
         my $unmatched = 1;
         while( $unmatched ) {
             if( defined( my $line = $sock->getline ) ) {
-                push @lines, $line;
-                $unmatched = 0 if($line =~ /\)/);
+                if($line =~ /^\)[\r\n]*$/) {
+                    $unmatched = 0;
+                } else {
+                    push @lines, $line;
+                }
             } else {
-                $self->_seterrstr( "error reading $count bytes from socket" );
+                $self->_seterrstr( "error matching ending parentheses after reading $count bytes from socket" );
                 last;
             }
         }


### PR DESCRIPTION
...better error message
- Make the end parentheses match look for a end parentheses on its own (with optional newline).
- Only put debug messages when in debugging mode
- Give a better (more descriptive) error message when we fail
