### PR TITLE
Add support for data items (not just body part specifiers) in ->get

### DIFF
--- a/Simple.pm
+++ b/Simple.pm
@@ -678,8 +678,7 @@ sub get {
     my $arg = $part ?
 		( $part =~ /[\[\]\<\>]/ ? $part : "BODY[$part]" )
 		: 'RFC822';
-	# XXX: if data item is recognised as part specifier,
-	# try putting it in brackets
+	# XXX: some data items will still be recognised as part specifiers
 
     my @lines;
     my $fetching;

--- a/Simple.pm
+++ b/Simple.pm
@@ -675,10 +675,13 @@ sub search_body    { my $self = shift; my $t = _process_qstring(shift); return $
 
 sub get {
     my ( $self, $number, $part ) = @_;
-    my $arg = $part ?
-		( $part =~ /[\[\]\<\>]/ ? $part : "BODY[$part]" )
-		: 'RFC822';
-	# XXX: some data items will still be recognised as part specifiers
+    my $arg = $part ? "BODY[$part]" : 'RFC822';
+	return $self->fetch( $number, $part );
+}
+
+sub fetch {
+    my ( $self, $number, $part ) = @_;
+    my $arg = $part or 'RFC822';
 
     my @lines;
     my $fetching;

--- a/Simple.pm
+++ b/Simple.pm
@@ -675,7 +675,11 @@ sub search_body    { my $self = shift; my $t = _process_qstring(shift); return $
 
 sub get {
     my ( $self, $number, $part ) = @_;
-    my $arg = $part ? "BODY[$part]" : 'RFC822';
+    my $arg = $part ?
+		( $part =~ /[\[\]\<\>]/ ? $part : "BODY[$part]" )
+		: 'RFC822';
+	# XXX: if data item is recognised as part specifier,
+	# try putting it in brackets
 
     my @lines;
     my $fetching;


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc3501#section-6.4.5 for examples.

Note: some data items may be recognised as body part specifiers. We may end up creating another method to FETCH messages' data items because distinguishing data items/body part specifiers may require parsing IMAP requests. For example,
this is a data item: (FLAGS BODY[HEADER.FIELDS (DATE FROM)])
this is a data item: (FLAGS INTERNALDATE RFC822.SIZE)
this is a data item: BODYSTRUCTURE
this is a body part specifier: HEADER.FIELDS (DATE FROM)
this is a body part specifier: 4.2.TEXT