### PR TITLE
Make the tests work with Zimbra

### DIFF
--- a/t/10_list.t
+++ b/t/10_list.t
@@ -29,8 +29,9 @@ sub run_tests {
     ok( int(keys %$h), 1 );
     my ($v) = values %$h;
 
-    my $bytes = $ENV{NIS_TEST_HOST} =~ m/gmail/ ? length($msg) : length($msg)+2;
-    ok( $v, $bytes )
+    # Some servers add two bytes, some don't.  Fine with us.
+    my($l0, $l2) = (length($msg), length($msg)+2);
+    ok( $v, qr/^(?:$l0|$l2)$/ )
 }
 
 do "./t/test_runner.pm";

--- a/t/55_uid_stuff.t
+++ b/t/55_uid_stuff.t
@@ -5,7 +5,7 @@ use Test;
 
 use Net::IMAP::Simple;
 
-plan tests => our $tests = 7;
+plan tests => our $tests = 2 * 3 + 3;
 
 our $imap;
 
@@ -13,9 +13,12 @@ sub run_tests {
     my $nm = $imap->select('testing')
         or die " failure selecting testing: " . $imap->errstr . "\n";
 
-    my @uidnext = ($imap->uidnext);
-    $imap->put( testing => "Subject: test1" ); push @uidnext, $imap->uidnext;
-    $imap->put( testing => "Subject: test2" );
+    my @uidnext;
+    for ( 1 .. (($tests - 3) / 3) ) {
+        push @uidnext, $imap->uidnext;
+        $imap->put( testing => "Subject: test$_" );
+        ok( $uidnext[-1] != $imap->uidnext );
+    }
 
     my @seq = $imap->search_since("1-Jan-1971");
     my @uid = $imap->uid(do{local $"=","; "@seq"});

--- a/t/75_back_and_forth.t
+++ b/t/75_back_and_forth.t
@@ -32,9 +32,13 @@ sub run_tests {
     # [...blib/lib/Net/IMAP/Simple.pm line 725 in sub _process_cmd] 56 BAD Error in IMAP command FETCH: Invalid messageset\r\n
     # [...blib/lib/Net/IMAP/Simple.pm line 1201 in sub _cmd_ok] 56 BAD Error in IMAP command FETCH: Invalid messageset\r\n
 
+    # Zimbra says
+    # [...re/perl5/Net/IMAP/Simple.pm line 1202 in sub _send_cmd] 56 FETCH 913 RFC822\r\n
+    # [...re/perl5/Net/IMAP/Simple.pm line 730 in sub _process_cmd] 56 BAD parse error: invalid message sequence number: 913\r\n
+    # [...re/perl5/Net/IMAP/Simple.pm line 1227 in sub _cmd_ok] 56 BAD parse error: invalid message sequence number: 913\r\n
 
     $imap->get($tests + 9_00); # finishing move
-    ok( $imap->errstr, qr(Invalid messageset|message not found)i );
+    ok( $imap->errstr, qr(invalid message|message not found)i );
 }   
 
 do "./t/test_runner.pm";

--- a/t/test_runner.pm
+++ b/t/test_runner.pm
@@ -83,10 +83,14 @@ if( __PACKAGE__->can('run_tests') ) {
         }
     }
 
+    $imap->noop;
+
     eval {
         run_tests();
 
     1} or warn "\nfail: $@\n";
+
+    $imap->noop;
 
     for my $mb (qw(test anotherthing blarg testing testing1 testing2 testing3)) {
         my $nm = $imap->select($mb);


### PR DESCRIPTION
I started to look into adding some feature to `Net::IMAP::Simple` and the first thing I always do is to run the tests to make sure I didn't break anything. The tests *did* break with my Zimbra test server though so I went and make them work with Zimbra.

The file `t/55_uid_stuff.t` I just refactored a bit, it still fails for me but the results look odd and I have to re-read the RFC to see if I ran into a Zimbra bug or some unexpected behaviour:

````
not ok 4
# Test 4 got: "1148" (t/55_uid_stuff.t at line 29)
#   Expected: "1145"
#  t/55_uid_stuff.t line 29 is:         ok($uid[$_], $uidnext[$_]);
````