### PR TITLE
Fix IMAP connection hang forever

### DIFF
--- a/lib/Net/IMAP/Simple.pm
+++ b/lib/Net/IMAP/Simple.pm
@@ -877,7 +877,7 @@ sub logout {
 
 sub quit {
     my ( $self, $hq ) = @_;
-    $self->_send_cmd('EXPUNGE'); # XXX: $self->expunge_mailbox?
+    $self->_process_cmd( cmd => ['EXPUNGE'], final => sub { 1 }, process => sub { } ); # XXX: $self->expunge_mailbox?
 
     if ( !$hq ) {
         # XXX: $self->logout?


### PR DESCRIPTION
I'm using OTRS and it tries to fetch mails from an IMAPS (port 993) account. It uses **Net:IMAP:Simple** for this task. Sometimes the process hangs forever and it is always right after this warning:
`[...cpan-lib/Net/IMAP/Simple.pm line 1197 in sub _seterrstr] warning unknown return string (id=8): 7 OK EXPUNGE completed.\r\n`

I've run tcpdump over this communication and no packet is sent either way because both, client and server already sent what was suposed to be sent. So, after this, the only way out is timeout from one side. It happens because the code does not wait command response to be processed.

This do not happen to be all the time, but just some attempts.

Changing this line fix this problem.


## Proposed change
Make EXPUNGE command, located at sub QUIT, be processed. This command was not processed, causing, sometimes, that both the client and the server to wait for each otherfor's answer. That answer never arrives, so timeout limit gets reached.

## Breaking change
Prevent missing some response code of EXPUNGE command avoiding timing out connection

## Additional information
Every use of Simple.pm generates this warning:
```
[...cpan-lib/Net/IMAP/Simple.pm line 881 in sub _process_cmd] 7 OK EXPUNGE completed.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1276 in sub _cmd_ok] 7 OK EXPUNGE completed.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1197 in sub _seterrstr] warning unknown return string (id=8): 7 OK EXPUNGE completed.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 881 in sub _process_cmd] * BYE Microsoft Exchange Server 2016 IMAP4 server signing off.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1276 in sub _cmd_ok] * BYE Microsoft Exchange Server 2016 IMAP4 server signing off.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 881 in sub _process_cmd] 8 OK LOGOUT completed.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1276 in sub _cmd_ok] 8 OK LOGOUT completed.\r\n
IMAPS: Connection to mailotrs.mpdft.mp.br closed.
```

By processing this command, every use of Simple.pm gets this result (no warning now):
```
[...cpan-lib/Net/IMAP/Simple.pm line 880 in sub _process_cmd] 4 OK EXPUNGE completed.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1276 in sub _cmd_ok] 4 OK EXPUNGE completed.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1251 in sub _send_cmd] 5 LOGOUT\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 881 in sub _process_cmd] * BYE Microsoft Exchange Server 2016 IMAP4 server signing off.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1276 in sub _cmd_ok] * BYE Microsoft Exchange Server 2016 IMAP4 server signing off.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 881 in sub _process_cmd] 5 OK LOGOUT completed.\r\n
[...cpan-lib/Net/IMAP/Simple.pm line 1276 in sub _cmd_ok] 5 OK LOGOUT completed.\r\n
IMAPS: Connection to mailotrs.mpdft.mp.br closed.
```

## Related Issue
- This PR is related to Issue: #123568 for [Net-IMAP-Simple: SSL connections hang forever](https://rt.cpan.org/Public/Bug/Display.html?id=123568)

